### PR TITLE
No non-essential allocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ test:
 	go mod tidy -modfile=testdata/go_test.mod
 	go test ./... -modfile=testdata/go_test.mod -coverprofile=coverage.out -covermode=count
 
+benchmark:
+	go test -bench . -benchmem -benchtime 10000x
+
 lint:
 	golangci-lint run ./...
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/k1LoW/rl
 
 go 1.21.0
 
-require golang.org/x/sync v0.3.0
+require (
+	github.com/go-chi/httprate v0.7.4
+	golang.org/x/sync v0.3.0
+)
+
+require github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/go-chi/httprate v0.7.4 h1:a2GIjv8he9LRf3712zxxnRdckQCm7I8y8yQhkJ84V6M=
+github.com/go-chi/httprate v0.7.4/go.mod h1:6GOYBSwnpra4CQfAKXu8sQZg+nZ0M1g9QnyFvxrAB8A=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=


### PR DESCRIPTION
It did not seem necessary to necessarily record all limiters, so we stopped unnecessary allocations.