### PR TITLE
WriteHeader() is called before Write(). Also, it is not possible to write the header twice.

### DIFF
--- a/rl.go
+++ b/rl.go
@@ -122,7 +122,6 @@ func (rl *rateLimiter) Handler(next http.Handler) http.Handler {
 		if err := eg.Wait(); err != nil {
 			// Handle first error
 			if e, ok := err.(*LimitError); ok {
-				http.Error(w, e.Error(), e.statusCode)
 				if e.lh.limiter.ShouldSetXRateLimitHeaders(err) {
 					w.Header().Set("X-RateLimit-Limit", fmt.Sprintf("%d", e.lh.reqLimit))
 					w.Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", e.lh.rateLimitRemaining))
@@ -136,6 +135,7 @@ func (rl *rateLimiter) Handler(next http.Handler) http.Handler {
 					e.lh.limiter.OnRequestLimit(e)(w, r)
 					return
 				}
+				http.Error(w, e.Error(), e.statusCode)
 				return
 			}
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/rl_test.go
+++ b/rl_test.go
@@ -1,8 +1,10 @@
 package rl_test
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/httprate"
@@ -50,8 +52,15 @@ func TestRL(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+					b, err := io.ReadAll(res.Body)
+					if err != nil {
+						t.Fatal(err)
+					}
 					defer res.Body.Close()
-					if res.StatusCode == http.StatusTooManyRequests {
+					if strings.Contains(string(b), "Too many requests") {
+						if res.StatusCode != tt.wantStatusCode {
+							t.Errorf("got %v want %v", res.StatusCode, tt.wantStatusCode)
+						}
 						break L
 					}
 					got++

--- a/testutil/limiter.go
+++ b/testutil/limiter.go
@@ -47,7 +47,11 @@ func (l *Limiter) ShouldSetXRateLimitHeaders(err error) bool {
 
 func (l *Limiter) OnRequestLimit(err error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusTooManyRequests)
+		if l.statusCode != 0 {
+			w.WriteHeader(l.statusCode)
+		} else {
+			w.WriteHeader(http.StatusTooManyRequests)
+		}
 		le, ok := err.(*rl.LimitError)
 		if !ok {
 			w.Write([]byte("Too many requests"))
@@ -55,9 +59,6 @@ func (l *Limiter) OnRequestLimit(err error) http.HandlerFunc {
 		}
 		msg := fmt.Sprintf("Too many requests. name: %s, ratelimit: %d req/%s, ratelimit-ramaining: %d, ratelimit-reset: %d", le.LimierName(), le.RequestLimit(), le.WindowLen(), le.RateLimitRemaining(), le.RateLimitReset())
 		w.Write([]byte(msg))
-		if l.statusCode != 0 {
-			w.WriteHeader(l.statusCode)
-		}
 	}
 }
 


### PR DESCRIPTION
WriteHeader() is called before Write().
ref: https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/net/http/server.go;l=118-138

Also, it is not possible to write the header twice.
ref: https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/net/http/server.go;l=1152