### PR TITLE
Revert "Close request body when response error in rl"

### DIFF
--- a/rl.go
+++ b/rl.go
@@ -97,7 +97,6 @@ func (rl *limitMw) Handler(next http.Handler) http.Handler {
 				continue
 			}
 			if err != nil {
-				_ = r.Body.Close()
 				http.Error(w, err.Error(), http.StatusPreconditionRequired)
 				return
 			}
@@ -165,11 +164,9 @@ func (rl *limitMw) Handler(next http.Handler) http.Handler {
 					e.lh.limiter.OnRequestLimit(e)(w, r)
 					return
 				}
-				_ = r.Body.Close()
 				http.Error(w, e.Error(), e.statusCode)
 				return
 			}
-			_ = r.Body.Close()
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
Reverts k1LoW/rl#25

> The Server will close the request body. The ServeHTTP Handler does not need to.

https://pkg.go.dev/net/http#Request
