### PR TITLE
Convert LimitError to interface

### DIFF
--- a/error.go
+++ b/error.go
@@ -5,18 +5,28 @@ import (
 	"time"
 )
 
-var _ error = &LimitError{}
+type LimitError interface {
+	error
+	LimierName() string
+	RequestLimit() int
+	WindowLen() time.Duration
+	RateLimitReset() int
+	RateLimitRemaining() int
+}
+
+var _ LimitError = &limitError{}
+
 var ErrRateLimitExceeded error = errors.New("rate limit exceeded")
 
-// LimitError is the error returned by the middleware.
-type LimitError struct {
+// limitError is the error returned by the middleware.
+type limitError struct {
 	statusCode int
 	err        error
 	lh         *limitHandler
 }
 
-func NewLimitError(statusCode int, err error, lh *limitHandler) *LimitError {
-	return &LimitError{
+func newLimitError(statusCode int, err error, lh *limitHandler) *limitError {
+	return &limitError{
 		statusCode: statusCode,
 		err:        err,
 		lh:         lh,
@@ -24,31 +34,31 @@ func NewLimitError(statusCode int, err error, lh *limitHandler) *LimitError {
 }
 
 // Error returns the error message.
-func (e *LimitError) Error() string {
+func (e *limitError) Error() string {
 	return e.err.Error()
 }
 
 // LimierName returns the name of the limiter that caused the error.
-func (e *LimitError) LimierName() string {
+func (e *limitError) LimierName() string {
 	return e.lh.limiter.Name()
 }
 
 // RequestLimit returns the request limit of the limiter that caused the error.
-func (e *LimitError) RequestLimit() int {
+func (e *limitError) RequestLimit() int {
 	return e.lh.reqLimit
 }
 
 // WindowLen returns the window length of the limiter that caused the error.
-func (e *LimitError) WindowLen() time.Duration {
+func (e *limitError) WindowLen() time.Duration {
 	return e.lh.windowLen
 }
 
 // RateLimitReset returns the number of seconds until the rate limit resets.
-func (e *LimitError) RateLimitReset() int {
+func (e *limitError) RateLimitReset() int {
 	return e.lh.rateLimitReset
 }
 
 // RateLimitRemaining returns the number of requests remaining in the current window.
-func (e *LimitError) RateLimitRemaining() int {
+func (e *limitError) RateLimitRemaining() int {
 	return e.lh.rateLimitRemaining
 }

--- a/testutil/limiter.go
+++ b/testutil/limiter.go
@@ -69,7 +69,7 @@ func (l *Limiter) OnRequestLimit(err error) http.HandlerFunc {
 		} else {
 			w.WriteHeader(http.StatusTooManyRequests)
 		}
-		le, ok := err.(*rl.LimitError)
+		le, ok := err.(rl.LimitError)
 		if !ok {
 			_, err = w.Write([]byte("Too many requests"))
 			if err != nil {


### PR DESCRIPTION
ref: #33 

Convert LimitError to interface for testing Limitter.OnRequestLimit() as well as error.