### PR TITLE
Review Limiter interface

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-var _ error = &LimitError{}
+var _ error = &Context{}
 var ErrRateLimitExceeded error = errors.New("rate limit exceeded")
 
-// LimitError is the error returned by the middleware.
-type LimitError struct {
+// Context is the error returned by the middleware.
+type Context struct {
 	StatusCode         int
 	Err                error
 	Limiter            Limiter
@@ -20,8 +20,8 @@ type LimitError struct {
 	lh                 *limitHandler
 }
 
-func newLimitError(statusCode int, err error, lh *limitHandler) *LimitError {
-	return &LimitError{
+func newContext(statusCode int, err error, lh *limitHandler) *Context {
+	return &Context{
 		StatusCode:         statusCode,
 		Err:                err,
 		Limiter:            lh.limiter,
@@ -34,6 +34,6 @@ func newLimitError(statusCode int, err error, lh *limitHandler) *LimitError {
 }
 
 // Error returns the error message.
-func (e *LimitError) Error() string {
+func (e *Context) Error() string {
 	return e.Err.Error()
 }

--- a/error.go
+++ b/error.go
@@ -10,45 +10,30 @@ var ErrRateLimitExceeded error = errors.New("rate limit exceeded")
 
 // LimitError is the error returned by the middleware.
 type LimitError struct {
-	statusCode int
-	err        error
-	lh         *limitHandler
+	StatusCode         int
+	Err                error
+	LimiterName        string
+	RequestLimit       int
+	WindowLen          time.Duration
+	RateLimitRemaining int
+	RateLimitReset     int
+	lh                 *limitHandler
 }
 
-func NewLimitError(statusCode int, err error, lh *limitHandler) *LimitError {
+func newLimitError(statusCode int, err error, lh *limitHandler) *LimitError {
 	return &LimitError{
-		statusCode: statusCode,
-		err:        err,
-		lh:         lh,
+		StatusCode:         statusCode,
+		Err:                err,
+		LimiterName:        lh.limiter.Name(),
+		RequestLimit:       lh.reqLimit,
+		WindowLen:          lh.windowLen,
+		RateLimitRemaining: lh.rateLimitRemaining,
+		RateLimitReset:     lh.rateLimitReset,
+		lh:                 lh,
 	}
 }
 
 // Error returns the error message.
 func (e *LimitError) Error() string {
-	return e.err.Error()
-}
-
-// LimierName returns the name of the limiter that caused the error.
-func (e *LimitError) LimierName() string {
-	return e.lh.limiter.Name()
-}
-
-// RequestLimit returns the request limit of the limiter that caused the error.
-func (e *LimitError) RequestLimit() int {
-	return e.lh.reqLimit
-}
-
-// WindowLen returns the window length of the limiter that caused the error.
-func (e *LimitError) WindowLen() time.Duration {
-	return e.lh.windowLen
-}
-
-// RateLimitReset returns the number of seconds until the rate limit resets.
-func (e *LimitError) RateLimitReset() int {
-	return e.lh.rateLimitReset
-}
-
-// RateLimitRemaining returns the number of requests remaining in the current window.
-func (e *LimitError) RateLimitRemaining() int {
-	return e.lh.rateLimitRemaining
+	return e.Err.Error()
 }

--- a/error.go
+++ b/error.go
@@ -12,7 +12,7 @@ var ErrRateLimitExceeded error = errors.New("rate limit exceeded")
 type LimitError struct {
 	StatusCode         int
 	Err                error
-	LimiterName        string
+	Limiter            Limiter
 	RequestLimit       int
 	WindowLen          time.Duration
 	RateLimitRemaining int
@@ -24,7 +24,7 @@ func newLimitError(statusCode int, err error, lh *limitHandler) *LimitError {
 	return &LimitError{
 		StatusCode:         statusCode,
 		Err:                err,
-		LimiterName:        lh.limiter.Name(),
+		Limiter:            lh.limiter,
 		RequestLimit:       lh.reqLimit,
 		WindowLen:          lh.windowLen,
 		RateLimitRemaining: lh.rateLimitRemaining,

--- a/testutil/limiter.go
+++ b/testutil/limiter.go
@@ -58,26 +58,18 @@ func (l *Limiter) Rule(r *http.Request) (*rl.Rule, error) {
 	}, nil
 }
 
-func (l *Limiter) ShouldSetXRateLimitHeaders(err error) bool {
+func (l *Limiter) ShouldSetXRateLimitHeaders(le *rl.LimitError) bool {
 	return true
 }
 
-func (l *Limiter) OnRequestLimit(err error) http.HandlerFunc {
+func (l *Limiter) OnRequestLimit(le *rl.LimitError) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if l.statusCode != 0 {
 			w.WriteHeader(l.statusCode)
 		} else {
 			w.WriteHeader(http.StatusTooManyRequests)
 		}
-		le, ok := err.(*rl.LimitError)
-		if !ok {
-			_, err = w.Write([]byte("Too many requests"))
-			if err != nil {
-				return
-			}
-			return
-		}
-		msg := fmt.Sprintf("Too many requests. name: %s, ratelimit: %d req/%s, ratelimit-ramaining: %d, ratelimit-reset: %d", le.LimierName(), le.RequestLimit(), le.WindowLen(), le.RateLimitRemaining(), le.RateLimitReset())
+		msg := fmt.Sprintf("Too many requests. name: %s, ratelimit: %d req/%s, ratelimit-ramaining: %d, ratelimit-reset: %d", le.LimiterName, le.RequestLimit, le.WindowLen, le.RateLimitRemaining, le.RateLimitReset)
 		_, _ = w.Write([]byte(msg)) //nostyle:handlerrors
 	}
 }

--- a/testutil/limiter.go
+++ b/testutil/limiter.go
@@ -58,11 +58,11 @@ func (l *Limiter) Rule(r *http.Request) (*rl.Rule, error) {
 	}, nil
 }
 
-func (l *Limiter) ShouldSetXRateLimitHeaders(le *rl.LimitError) bool {
+func (l *Limiter) ShouldSetXRateLimitHeaders(le *rl.Context) bool {
 	return true
 }
 
-func (l *Limiter) OnRequestLimit(le *rl.LimitError) http.HandlerFunc {
+func (l *Limiter) OnRequestLimit(le *rl.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if l.statusCode != 0 {
 			w.WriteHeader(l.statusCode)

--- a/testutil/limiter.go
+++ b/testutil/limiter.go
@@ -69,7 +69,7 @@ func (l *Limiter) OnRequestLimit(le *rl.LimitError) http.HandlerFunc {
 		} else {
 			w.WriteHeader(http.StatusTooManyRequests)
 		}
-		msg := fmt.Sprintf("Too many requests. name: %s, ratelimit: %d req/%s, ratelimit-ramaining: %d, ratelimit-reset: %d", le.LimiterName, le.RequestLimit, le.WindowLen, le.RateLimitRemaining, le.RateLimitReset)
+		msg := fmt.Sprintf("Too many requests. name: %s, ratelimit: %d req/%s, ratelimit-ramaining: %d, ratelimit-reset: %d", le.Limiter.Name(), le.RequestLimit, le.WindowLen, le.RateLimitRemaining, le.RateLimitReset)
 		_, _ = w.Write([]byte(msg)) //nostyle:handlerrors
 	}
 }


### PR DESCRIPTION
- Rename LimitError to Context.
- Accept Context straight away.
- Fix Context to retain the value of limitHandler at the time of
- Export Context fields for implementing Limiter