### PR TITLE
The domain that has hit the rate limit is what I want to know.

### DIFF
--- a/context.go
+++ b/context.go
@@ -17,6 +17,7 @@ type Context struct {
 	WindowLen          time.Duration
 	RateLimitRemaining int
 	RateLimitReset     int
+	Key                string
 	lh                 *limitHandler
 }
 
@@ -29,6 +30,7 @@ func newContext(statusCode int, err error, lh *limitHandler) *Context {
 		WindowLen:          lh.windowLen,
 		RateLimitRemaining: lh.rateLimitRemaining,
 		RateLimitReset:     lh.rateLimitReset,
+		Key:                lh.key,
 		lh:                 lh,
 	}
 }


### PR DESCRIPTION
For instance, when imposing rate limits on a per-domain basis, users would want to know which domains have been affected by the rate limit.