### PR TITLE
In cases within OnRequestLimit, I want to execute next.

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package rl
 
 import (
 	"errors"
+	"net/http"
 	"time"
 )
 
@@ -17,10 +18,11 @@ type Context struct {
 	WindowLen          time.Duration
 	RateLimitRemaining int
 	RateLimitReset     int
+	Next               http.Handler
 	lh                 *limitHandler
 }
 
-func newContext(statusCode int, err error, lh *limitHandler) *Context {
+func newContext(statusCode int, err error, lh *limitHandler, next http.Handler) *Context {
 	return &Context{
 		StatusCode:         statusCode,
 		Err:                err,
@@ -29,6 +31,7 @@ func newContext(statusCode int, err error, lh *limitHandler) *Context {
 		WindowLen:          lh.windowLen,
 		RateLimitRemaining: lh.rateLimitRemaining,
 		RateLimitReset:     lh.rateLimitReset,
+		Next:               next,
 		lh:                 lh,
 	}
 }

--- a/rl.go
+++ b/rl.go
@@ -116,23 +116,23 @@ func (lm *limitMw) Handler(next http.Handler) http.Handler {
 				case <-ctx.Done():
 					// Increment must be called even if the request limit is already exceeded
 					if err := lh.limiter.Increment(lh.key, currWindow); err != nil {
-						return newContext(http.StatusInternalServerError, err, lh)
+						return newContext(http.StatusInternalServerError, err, lh, next)
 					}
 					return nil
 				default:
 				}
 				rate, err := lh.status(now, currWindow)
 				if err != nil {
-					return newContext(http.StatusPreconditionRequired, err, lh)
+					return newContext(http.StatusPreconditionRequired, err, lh, next)
 				}
 				nrate := int(math.Round(rate))
 				if nrate >= lh.reqLimit {
-					return newContext(http.StatusTooManyRequests, ErrRateLimitExceeded, lh)
+					return newContext(http.StatusTooManyRequests, ErrRateLimitExceeded, lh, next)
 				}
 
 				lh.rateLimitRemaining = lh.reqLimit - nrate
 				if err := lh.limiter.Increment(lh.key, currWindow); err != nil {
-					return newContext(http.StatusInternalServerError, err, lh)
+					return newContext(http.StatusInternalServerError, err, lh, next)
 				}
 				return nil
 			})


### PR DESCRIPTION
I want to enable the process to continue based on the user's decision in cases where the rate limit is reached but a 502 response is not desired.